### PR TITLE
Add 基調カラーパレッド3色を登録

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ module.exports = {
     extend: {
       colors: {
         "primary-orange": "#DA5019",
-        "primary-variant-orange": "EC9F05",
+        "primary-variant-orange": "#EC9F05",
         "secondary-cyan": "#79DEE3",
       },
     },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,13 @@
 module.exports = {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        "primary-orange": "#DA5019",
+        "primary-variant-orange": "EC9F05",
+        "secondary-cyan": "#79DEE3",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
# Issue番号
fixed #20 

# このPRがしたいこと
Figmaで利用している三色のカラーパレッドをtailwind.config.jsに追加し、いつでも呼び出せるようにすることで、コーディング時にカラーコードを指定する負担を削減する。
- プライマリーカラー（オレンジ）
`#DA5019`
- バリアントカラー（黄色）
`#EC9F05`
- セカンダリーカラー（シアン）
`#79DEE3`
  
上記三色はtailwindのデフォルトカラーに存在していない色のため、カラーコードを直接指定する必要がありました。  
  
# 再現方法
```js
<div className="bg-primary-orange">
```
のように指定することで、登録した上記3色を呼び出せます。

# レビュアーに確認してほしいこと

# 相談事項
特になし