### PR TITLE
iframe用のHTMLを生成

### DIFF
--- a/src/pages/test.jsx
+++ b/src/pages/test.jsx
@@ -1,0 +1,33 @@
+import Head from "next/head";
+import Image from "next/image";
+import makeIframe from "../utils/makeIframe";
+import React, { useState, useEffect } from "react";
+
+export default function Test() {
+  const [Iframe, setIframe] = useState("<h1>👆ボタンを押してね<h1>");
+  const handleClick = () => {
+    var uri = new URL(window.location.href);
+    // URL (http://localhost, https://hoge.com)
+    const host = uri.protocol + "//" + uri.host;
+    // データベースに存在しているIDを指定する string
+    const id = "wBXrAVrONYEMUrjB";
+    // 埋め込みたいiframeの縦横のサイズ number
+    const width = 300;
+    const height = 500;
+    // iframeにオレンジの枠を付けるか bool
+    const border = true;
+    const Iframe = makeIframe(host, id, width, height, border);
+    setIframe(Iframe);
+  };
+  return (
+    <div>
+      <h1 className="text-5xl font-bold underline">Testページ</h1>
+      <br />
+      <br />
+      <div className="m-5">
+        <button onClick={handleClick}>ボタン</button>
+        <div dangerouslySetInnerHTML={{ __html: Iframe }} />
+      </div>
+    </div>
+  );
+}

--- a/src/utils/makeIframe.js
+++ b/src/utils/makeIframe.js
@@ -1,0 +1,11 @@
+const makeIframe = (host, id, width, height, border) => {
+  return `<iframe
+    style="border-radius:12px;${border && "border: 2px #DA5019 solid;"}"
+    src="${host}/myList/${id}"
+    width="${width}"
+    height="${height}"
+    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+  ></iframe>`;
+};
+
+export default makeIframe;


### PR DESCRIPTION
# Issue番号
#10

# このPRがしたいこと
iframe用のHTMLタグを生成する
![image](https://user-images.githubusercontent.com/72294945/161385090-b31caf4e-24e9-445c-82fb-2cb1e969f568.png)

# 再現方法
仮で`/test`にアクセスすると再現できます。使い方については、`/pages/test.jsx`を参照してください。

# レビュアーに確認してほしいこと

# 相談事項