### PR TITLE
Fix URLの入力とレスポンスの状態に応じて埋め込みボックスが生成されるように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@headlessui/react": "^1.5.0",
     "axios": "^0.26.1",
     "next": "12.1.0",
     "react": "17.0.2",

--- a/src/components/ClipedModal.jsx
+++ b/src/components/ClipedModal.jsx
@@ -1,0 +1,79 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { Fragment } from "react";
+
+export default function ClipedModal(props) {
+  function closeModal() {
+    props.setIsOpen(false);
+  }
+  return (
+    <Transition appear show={props.isOpen} as={Fragment}>
+      <Dialog
+        as="div"
+        className="fixed inset-0 z-10 overflow-y-auto"
+        onClose={closeModal}
+      >
+        <div className="min-h-screen px-4 text-center">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Dialog.Overlay className="fixed inset-0" />
+          </Transition.Child>
+
+          {/* This element is to trick the browser into centering the modal contents. */}
+          <span
+            className="inline-block h-screen align-middle"
+            aria-hidden="true"
+          >
+            &#8203;
+          </span>
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <div className="inline-block w-full max-w-md p-6 my-8 overflow-hidden text-left align-middle transition-all transform bg-white shadow-xl rounded-2xl">
+              <Dialog.Title
+                as="h3"
+                className="text-lg font-medium leading-6 text-gray-900"
+              >
+                <div className="flex justify-center">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-32 w-32 text-primary-orange"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                </div>
+              </Dialog.Title>
+              <div className="mt-2">
+                <p className="text-sm text-gray-500">
+                  Paste this code directly into the HTML portion of your site,
+                  and you'll be good to go. Need more info? Check out our
+                  developer docs.{" "}
+                </p>
+              </div>
+            </div>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -2,13 +2,19 @@ import LogoIcon from "./LogoIcon";
 
 export default function Header(props) {
   return (
-    <div className="p-48 bg-primary-orange shadow-md">
+    <div className="p-8 bg-primary-orange shadow-md">
       <div>
+        <div className="flex justify-end">
+          <LogoIcon width={180} height={180} />
+        </div>
         <div className="flex justify-center">
-          <h1 className="my-16 mx-16 text-white text-4xl font-bold">
-            Let's d-anime-embed!
+          <h1 className="my-16 mx-16 text-white text-5xl font-bold">
+            Lets share your MyList
           </h1>
-          <LogoIcon width={100} height={100} />
+          <br />
+          <p className="my-16 mx-16 text-cyan text-small">
+            Lets share your MyList
+          </p>
         </div>
         <div className="relative">
           <div className="flex justify-center p-2 mb-2">

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -8,16 +8,17 @@ export default function Header(props) {
           <LogoIcon width={180} height={180} />
         </div>
         <div className="flex justify-center">
-          <h1 className="my-16 mx-16 text-white text-5xl font-bold">
-            Lets share your MyList
+          <h1 className="my-4 mx-16 text-white text-5xl font-bold">
+            Let's share your MyList
           </h1>
-          <br />
-          <p className="my-16 mx-16 text-cyan text-small">
-            Lets share your MyList
+        </div>
+        <div className="flex justify-center">
+          <p className="my-2 mx-4 text-secondary-cyan text-small font-bold">
+            あなたのマイリストをあらゆるメディアに埋め込みましょう
           </p>
         </div>
         <div className="relative">
-          <div className="flex justify-center p-2 mb-2">
+          <div className="flex justify-center p-2 mb-2 my-8">
             <input
               className="cursor-pointer shadow appearance-none border rounded-lg w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
               type="search"

--- a/src/components/Iframe.jsx
+++ b/src/components/Iframe.jsx
@@ -1,18 +1,7 @@
 import makeIframe from "../utils/makeIframe";
-import React, { useState, useEffect } from "react";
+import React from "react";
 
 export default function Iframe(props) {
-  function copyTextToClipboard() {
-    navigator.clipboard.writeText(IframeUrl).then(
-      function () {
-        window.alert("Copied!");
-      },
-      function (err) {
-        console.error("Async: Could not copy text: ", err);
-      }
-    );
-  }
-
   var uri = props.uri;
   // URL (http://localhost, https://hoge.com)
   const host = uri.protocol + "//" + uri.host;
@@ -25,32 +14,49 @@ export default function Iframe(props) {
   const border = props.border;
   const IframeUrl = makeIframe(host, id, width, height, border);
   const message = props.message;
-  const flag = props.flag;
+  const generated = props.generated;
+
+  function openModal() {
+    props.setIsOpen(true);
+  }
+  function copyTextToClipboard() {
+    navigator.clipboard.writeText(IframeUrl).then(
+      function () {
+        // window.alert("Copied!");
+        openModal();
+      },
+      function (err) {
+        console.error("Async: Could not copy text: ", err);
+      }
+    );
+  }
 
   return (
     <div>
       <div className="m-5">
         <div
           className={
-            flag ? "cursor-wait flex justify-center" : "flex justify-center"
+            generated
+              ? "cursor-wait flex justify-center"
+              : "flex justify-center"
           }
         >
           <input
             className={
-              flag
+              generated
                 ? "pointer-events-none shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
                 : "shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
             }
-            placeholder={flag ? message : IframeUrl}
+            placeholder={generated ? message : IframeUrl}
             onClick={() => {
-              copyTextToClipboard(IframeUrl);
+              copyTextToClipboard();
             }}
           />
           <span className="shadow-inner inline-flex items-center px-3 bg-primary-orange rounded-r-lg border border-r-0 hover:bg-primary-variant-orange">
             <button
-              className={flag ? "pointer-events-none cursor-wait" : ""}
+              className={generated ? "pointer-events-none cursor-wait" : ""}
               onClick={() => {
-                copyTextToClipboard(IframeUrl);
+                copyTextToClipboard();
               }}
             >
               <svg
@@ -69,7 +75,9 @@ export default function Iframe(props) {
           </span>
         </div>
         <div className="flex justify-center">
-          {!flag && <div dangerouslySetInnerHTML={{ __html: IframeUrl }} />}
+          {!generated && (
+            <div dangerouslySetInnerHTML={{ __html: IframeUrl }} />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Iframe.jsx
+++ b/src/components/Iframe.jsx
@@ -13,35 +13,46 @@ export default function Iframe(props) {
     );
   }
 
-  const [Iframe, setIframe] = useState("");
-  const handleClick = () => {
-    var uri = new URL(window.location.href);
-    // URL (http://localhost, https://hoge.com)
-    const host = uri.protocol + "//" + uri.host;
-    // データベースに存在しているIDを指定する string
-    const id = props.mylistId ? props.mylistId : "";
-    // 埋め込みたいiframeの縦横のサイズ number
-    const width = props.width;
-    const height = props.height;
-    // iframeにオレンジの枠を付けるか bool
-    const border = props.border;
-    const IframeUrl = makeIframe(host, id, width, height, border);
-    setIframe(IframeUrl);
-    copyTextToClipboard(Iframe);
-  };
+  var uri = props.uri;
+  // URL (http://localhost, https://hoge.com)
+  const host = uri.protocol + "//" + uri.host;
+  // データベースに存在しているIDを指定する string
+  const id = props.mylistId ? props.mylistId : "";
+  // 埋め込みたいiframeの縦横のサイズ number
+  const width = props.width;
+  const height = props.height;
+  // iframeにオレンジの枠を付けるか bool
+  const border = props.border;
+  const IframeUrl = makeIframe(host, id, width, height, border);
+  const message = props.message;
+  const flag = props.flag;
+
   return (
     <div>
       <div className="m-5">
-        <div className="flex justify-center">
+        <div
+          className={
+            flag ? "cursor-wait flex justify-center" : "flex justify-center"
+          }
+        >
           <input
-            className="shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
-            placeholder={
-              Iframe ? Iframe : "クリックで埋め込みボックスを生成する"
+            className={
+              flag
+                ? "pointer-events-none shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
+                : "shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
             }
-            onClick={handleClick}
+            placeholder={flag ? message : IframeUrl}
+            onClick={() => {
+              copyTextToClipboard(IframeUrl);
+            }}
           />
           <span className="shadow-inner inline-flex items-center px-3 bg-primary-orange rounded-r-lg border border-r-0 hover:bg-primary-variant-orange">
-            <button onClick={handleClick}>
+            <button
+              className={flag ? "pointer-events-none cursor-wait" : ""}
+              onClick={() => {
+                copyTextToClipboard(Iframe);
+              }}
+            >
               <svg
                 width="32"
                 height="32"
@@ -58,7 +69,7 @@ export default function Iframe(props) {
           </span>
         </div>
         <div className="flex justify-center">
-          <div dangerouslySetInnerHTML={{ __html: Iframe }} />
+          {!flag && <div dangerouslySetInnerHTML={{ __html: IframeUrl }} />}
         </div>
       </div>
     </div>

--- a/src/components/Iframe.jsx
+++ b/src/components/Iframe.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from "react";
 
 export default function Iframe(props) {
   function copyTextToClipboard() {
-    navigator.clipboard.writeText(Iframe).then(
+    navigator.clipboard.writeText(IframeUrl).then(
       function () {
         window.alert("Copied!");
       },
@@ -50,7 +50,7 @@ export default function Iframe(props) {
             <button
               className={flag ? "pointer-events-none cursor-wait" : ""}
               onClick={() => {
-                copyTextToClipboard(Iframe);
+                copyTextToClipboard(IframeUrl);
               }}
             >
               <svg

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -1,21 +1,25 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, Fragment } from "react";
 import Iframe from "../components/Iframe";
 import Header from "../components/Header";
 import axios from "../utils/axios";
+import { Switch } from "@headlessui/react";
+
+import ClipedModal from "../components/ClipedModal";
 
 export default function Home() {
-  const [isBorder, setIsBorder] = useState(true);
   const [mylisturl, setMylistUrl] = useState("");
   const [mylistId, setMylistId] = useState("");
   const [width, setWidth] = useState(500);
   const [height, setHeight] = useState(300);
   const [message, setMessage] = useState("埋め込みボックスを生成する");
   const [uri, setUri] = useState("");
-  const [flag, flagChange] = useState(Boolean);
+  const [generated, setGenerated] = useState(Boolean);
+  const [isOpen, setIsOpen] = useState(false);
+  const [enabled, setEnabled] = useState(true);
 
   useEffect(() => {
     console.log("called");
-    flagChange(true);
+    setGenerated(true);
     (async () => {
       setUri(new URL(window.location.href));
       setMessage("埋め込みボックスを生成中");
@@ -36,7 +40,7 @@ export default function Home() {
             setMylistId(res.data.mylist_id);
             console.log(res.data.mylist_id);
             setMessage(mylistId);
-            flagChange(false);
+            setGenerated(false);
           });
       } catch (err) {
         switch (err.response?.status) {
@@ -53,7 +57,7 @@ export default function Home() {
               .then((res) => {
                 setMylistId(res.data.mylist_id);
                 console.log(res.data.mylist_id);
-                flagChange(false);
+                setGenerated(false);
               });
           default:
             console.log(err);
@@ -68,37 +72,27 @@ export default function Home() {
 
   return (
     <div>
+      <ClipedModal isOpen={isOpen} setIsOpen={setIsOpen} />
       <Header setMylistUrl={setMylistUrl} />
       <div className="flex justify-center">埋め込みオプションを設定</div>
 
       <div className="container mx-auto px-4 flex justify-center">
         <div className="block">
           <div className="mt-2">
-            <div className="mt-4">
-              <div className="mt-2">
-                <label className="inline-flex items-center">
-                  <input
-                    type="radio"
-                    className="form-radio"
-                    name="borderType"
-                    value="枠線なし"
-                    checked="checked"
-                    onChange={() => setIsBorder(false)}
-                  />
-                  <span className="ml-2">枠線なし</span>
-                </label>
-                <label className="inline-flex items-center ml-6">
-                  <input
-                    type="radio"
-                    className="form-radio"
-                    name="borderType"
-                    value="枠線あり"
-                    onChange={() => setIsBorder(true)}
-                  />
-                  <span className="ml-2">枠線あり</span>
-                </label>
-              </div>
-            </div>
+            <Switch
+              checked={enabled}
+              onChange={() => setEnabled(!enabled)}
+              className={`${
+                enabled ? "bg-blue-600" : "bg-gray-200"
+              } relative inline-flex items-center h-6 rounded-full w-11`}
+            >
+              <span className="sr-only">Enable notifications</span>
+              <span
+                className={`${
+                  enabled ? "translate-x-6" : "translate-x-1"
+                } inline-block w-4 h-4 transform bg-white rounded-full`}
+              />
+            </Switch>
             <label className="block mt-4">
               <span className="text-gray-700">横幅を選択する</span>
               <select className="form-select mt-1 block w-full">
@@ -127,10 +121,11 @@ export default function Home() {
               mylistId={mylistId}
               width={width}
               height={height}
-              border={isBorder}
+              border={enabled}
               message={message}
               uri={uri}
-              flag={flag}
+              generated={generated}
+              setIsOpen={setIsOpen}
             />
           }
         </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -9,10 +9,16 @@ export default function Home() {
   const [mylistId, setMylistId] = useState("");
   const [width, setWidth] = useState(500);
   const [height, setHeight] = useState(300);
+  const [message, setMessage] = useState("埋め込みボックスを生成する");
+  const [uri, setUri] = useState("");
+  const [flag, flagChange] = useState(Boolean);
 
   useEffect(() => {
     console.log("called");
+    flagChange(true);
     (async () => {
+      setUri(new URL(window.location.href));
+      setMessage("埋め込みボックスを生成中");
       const headers = {
         accept: "application/json",
         "Content-Type": "application/json",
@@ -29,6 +35,8 @@ export default function Home() {
           .then((res) => {
             setMylistId(res.data.mylist_id);
             console.log(res.data.mylist_id);
+            setMessage(mylistId);
+            flagChange(false);
           });
       } catch (err) {
         switch (err.response?.status) {
@@ -45,6 +53,7 @@ export default function Home() {
               .then((res) => {
                 setMylistId(res.data.mylist_id);
                 console.log(res.data.mylist_id);
+                flagChange(false);
               });
           default:
             console.log(err);
@@ -52,6 +61,10 @@ export default function Home() {
       }
     })();
   }, [mylisturl]);
+
+  useEffect(() => {
+    setMessage("埋め込みボックスを生成する");
+  }, []);
 
   return (
     <div>
@@ -114,6 +127,9 @@ export default function Home() {
               width={width}
               height={height}
               border={isBorder}
+              message={message}
+              uri={uri}
+              flag={flag}
             />
           }
         </div>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -82,6 +82,7 @@ export default function Home() {
                     className="form-radio"
                     name="borderType"
                     value="枠線なし"
+                    checked="checked"
                     onChange={() => setIsBorder(false)}
                   />
                   <span className="ml-2">枠線なし</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@headlessui/react@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.5.0.tgz#483b44ba2c8b8d4391e1d2c863898d7dd0cc0296"
+  integrity sha512-aaRnYxBb3MU2FNJf3Ut9RMTUqqU3as0aI1lQhgo2n9Fa67wRu14iOGqx93xB+uMNVfNwZ5B3y/Ndm7qZGuFeMQ==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz"


### PR DESCRIPTION
# Issue番号
fixed #53 
fixed #49 
fixed #46

# このPRがしたいこと
- https://github.com/Aruminium/d-anime-mylist-frontend/pull/47 より
  - 操作性の改善のため、枠線の有無をトグルで強調する
  - コピー時のモーダルウィンドウを修正する
- ロゴとタイトルの配置などレイアウト修正 #49 
- URLの入力とレスポンスの状態に応じて埋め込みボックスが生成されるように処理を修正したい #53 

# 再現方法
1. http://localhost:3000/
にアクセスし、入力フォームに任意のマイリストURLを入力
2. マイリスト生成中（バックエンドからのレスポンス待ち）のときクリップボード部分がクリック不可能となっていることを確認
3. 埋め込みオプションから任意の項目を選択すること
4. マイリスト生成後iframeのURLがクリップボードウィンドウ内に表示され、クリップボードウィンドウ及びボタンがクリック可能となっており、クリック後にモーダルウィンドウで「Copied！」と表示されること

# レビュアーに確認してほしいこと
- 上記の再現方法の通りに操作を行い、フローが達成できるか

# 留意事項
- 外枠を操作するトグルをOFFにしたとき、埋め込みボックスの表示が切り替わるのに若干ラグがあります
- このPRがマージされた後、https://github.com/Aruminium/d-anime-mylist-frontend/pull/47 はcloseします

下記は別PRでの対応とします。
- https://github.com/Aruminium/d-anime-mylist-frontend/issues/55

# 相談事項
その他バグなどあればおしらせください