### PR TITLE
Fix トップページのレスポンシブ対応

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,12 +12,12 @@ export default function Header(props) {
             alt="logo"
           />
         </div>
-        <div className="flex justify-center">
+        <div className="md:flex justify-center">
           <h1 className="my-4 mx-16 text-white text-5xl font-bold">
             Lets share your MyList
           </h1>
         </div>
-        <div className="flex justify-center">
+        <div className="md:flex justify-center">
           <p className="my-2 mx-4 text-secondary-cyan text-small font-bold">
             あなたのマイリストをあらゆるメディアに埋め込みましょう
           </p>
@@ -25,7 +25,7 @@ export default function Header(props) {
         <div className="relative">
           <div className="flex justify-center p-2 mb-2 my-8">
             <input
-              className="cursor-pointer shadow appearance-none border rounded-lg w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
+              className="cursor-pointer shadow appearance-none border rounded-lg md:w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
               type="search"
               placeholder="マイリストのURLを入力してください"
               onChange={(e) => props.setMylistUrl(e.target.value)}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -25,7 +25,7 @@ export default function Header(props) {
         <div className="relative">
           <div className="flex justify-center p-2 mb-2 my-8">
             <input
-              className="cursor-pointer shadow appearance-none border rounded-lg md:w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
+              className="cursor-pointer shadow appearance-none border rounded-lg md:w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline hover:bg-gray-200"
               type="search"
               placeholder="マイリストのURLを入力してください"
               onChange={(e) => props.setMylistUrl(e.target.value)}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ export default function Header(props) {
   return (
     <div className="p-8 bg-primary-orange shadow-md">
       <div>
-        <div className="flex justify-end md:w-full w-16">
+        <div className="flex justify-end lg:w-full w-16">
           <Image
             src="/images/LogoIcon.png"
             width={180}
@@ -12,20 +12,20 @@ export default function Header(props) {
             alt="logo"
           />
         </div>
-        <div className="md:flex justify-center">
+        <div className="lg:flex justify-center">
           <h1 className="my-4 mx-16 text-white text-5xl font-bold">
             Lets share your MyList
           </h1>
         </div>
-        <div className="md:flex justify-center">
-          <p className="md:my-2 md:mx-4 text-secondary-cyan md:text-small font-bold">
+        <div className="lg:flex justify-center">
+          <p className="lg:my-2 lg:mx-4 text-secondary-cyan lg:text-small font-bold">
             あなたのマイリストをあらゆるメディアに埋め込みましょう
           </p>
         </div>
         <div className="relative">
           <div className="flex justify-center p-2 mb-2 my-8">
             <input
-              className="cursor-pointer shadow appearance-none border rounded-lg md:w-2/3 py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline hover:bg-gray-200"
+              className="cursor-pointer shadow appearance-none border rounded-lg lg:w-2/3 w-full py-4 px-4 text-gray-700 leading-tight focus:outline-none focus:shadow-outline hover:bg-gray-200"
               type="search"
               placeholder="マイリストのURLを入力してください"
               onChange={(e) => props.setMylistUrl(e.target.value)}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -13,12 +13,12 @@ export default function Header(props) {
           />
         </div>
         <div className="lg:flex justify-center">
-          <h1 className="my-4 mx-16 text-white text-5xl font-bold">
+          <h1 className="lg:my-4 lg:mx-16 text-white lg:text-5xl text-2xl font-bold">
             Lets share your MyList
           </h1>
         </div>
         <div className="lg:flex justify-center">
-          <p className="lg:my-2 lg:mx-4 text-secondary-cyan lg:text-small font-bold">
+          <p className="my-2 lg:mx-4 text-secondary-cyan font-bold">
             あなたのマイリストをあらゆるメディアに埋め込みましょう
           </p>
         </div>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -4,7 +4,7 @@ export default function Header(props) {
   return (
     <div className="p-8 bg-primary-orange shadow-md">
       <div>
-        <div className="flex justify-end">
+        <div className="flex justify-end md:w-full w-16">
           <Image
             src="/images/LogoIcon.png"
             width={180}
@@ -18,7 +18,7 @@ export default function Header(props) {
           </h1>
         </div>
         <div className="md:flex justify-center">
-          <p className="my-2 mx-4 text-secondary-cyan text-small font-bold">
+          <p className="md:my-2 md:mx-4 text-secondary-cyan md:text-small font-bold">
             あなたのマイリストをあらゆるメディアに埋め込みましょう
           </p>
         </div>

--- a/src/components/Iframe.jsx
+++ b/src/components/Iframe.jsx
@@ -33,8 +33,8 @@ export default function Iframe(props) {
           <input
             className={
               generating || message.indexOf("<") == -1
-                ? "pointer-events-none shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
-                : "shadow-inner appearance-none border w-1/2 py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
+                ? "pointer-events-none shadow-inner appearance-none border lg:w-1/2 w-full py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
+                : "shadow-inner appearance-none border lg:w-1/2 w-full py-4 px-4 text-gray-700 leading-tight rounded-l-lg focus:outline-none hover:bg-gray-200"
             }
             placeholder={message}
             onClick={() => {

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -123,7 +123,7 @@ export default function Home() {
             <div className="md:flex justify-center">
               埋め込みオプションを設定
             </div>
-            <div className="mdcontainer mx-auto px-4 md:flex justify-center">
+            <div className="container mx-auto px-4 md:flex justify-center">
               <div className="block">
                 <div className="md:mt-2">
                   <div className="md:flex my-3">
@@ -160,7 +160,7 @@ export default function Home() {
                       <p>縦(px)</p>
                       <input
                         type="number"
-                        className="cursor-pointer shadow appearance-none border rounded-lg py-2 px-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
+                        className="cursor-pointer shadow appearance-none border rounded-lg py-2 px-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline hover:bg-gray-200"
                         defaultValue={height}
                         placeholder="縦幅(px)"
                         onChange={(e) => setHeight(e.target.value)}

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -118,13 +118,15 @@ export default function Home() {
       <div>
         <ClipedModal isOpen={isOpen} setIsOpen={setIsOpen} />
         <Header setMylistUrl={setMylistUrl} />
-        <div className="flex justify-center items-center mt-3">
-          <div className="p-4 w-1/3 border-solid border-2 border-bg-gray-200 rounded-md">
-            <div className="flex justify-center">埋め込みオプションを設定</div>
-            <div className="container mx-auto px-4 flex justify-center">
+        <div className="md:flex justify-center items-center mt-3">
+          <div className="p-4 md:w-1/3 border-solid border-2 border-bg-gray-200 rounded-md">
+            <div className="md:flex justify-center">
+              埋め込みオプションを設定
+            </div>
+            <div className="mdcontainer mx-auto px-4 md:flex justify-center">
               <div className="block">
-                <div className="mt-2">
-                  <div className="flex my-3">
+                <div className="md:mt-2">
+                  <div className="md:flex my-3">
                     <Switch
                       checked={enabled}
                       onChange={() => setEnabled(!enabled)}
@@ -143,18 +145,18 @@ export default function Home() {
                       {enabled ? <>枠線あり</> : <>枠線なし</>}
                     </p>
                   </div>
-                  <div className="flex mt-3">
-                    <div className="mr-1">
+                  <div className="md:flex mt-3">
+                    <div className="md:mr-1">
                       <p>横(px)</p>
                       <input
                         type="number"
-                        className="cursor-pointer shadow appearance-none border rounded-lg py-2 px-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline  hover:bg-gray-200"
+                        className="cursor-pointer shadow appearance-none border rounded-lg py-2 px-2 text-gray-700 leading-tight focus:outline-none focus:shadow-outline hover:bg-gray-200"
                         placeholder="横幅(px)"
                         defaultValue={width}
                         onChange={(e) => setWidth(e.target.value)}
                       />
                     </div>
-                    <div className="ml-1">
+                    <div className="md:ml-1">
                       <p>縦(px)</p>
                       <input
                         type="number"

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -118,15 +118,15 @@ export default function Home() {
       <div>
         <ClipedModal isOpen={isOpen} setIsOpen={setIsOpen} />
         <Header setMylistUrl={setMylistUrl} />
-        <div className="md:flex justify-center items-center mt-3">
-          <div className="p-4 md:w-1/3 border-solid border-2 border-bg-gray-200 rounded-md">
-            <div className="md:flex justify-center">
+        <div className="lg:flex justify-center items-center mt-3">
+          <div className="p-4 lg:w-1/3 border-solid border-2 border-bg-gray-200 rounded-md">
+            <div className="lg:flex justify-center">
               埋め込みオプションを設定
             </div>
-            <div className="container mx-auto px-4 md:flex justify-center">
+            <div className="container mx-auto px-4 lg:flex justify-center">
               <div className="block">
-                <div className="md:mt-2">
-                  <div className="md:flex my-3">
+                <div className="lg:mt-2">
+                  <div className="lg:flex my-3">
                     <Switch
                       checked={enabled}
                       onChange={() => setEnabled(!enabled)}
@@ -145,8 +145,8 @@ export default function Home() {
                       {enabled ? <>枠線あり</> : <>枠線なし</>}
                     </p>
                   </div>
-                  <div className="md:flex mt-3">
-                    <div className="md:mr-1">
+                  <div className="lg:flex mt-3">
+                    <div className="lg:mr-1">
                       <p>横(px)</p>
                       <input
                         type="number"
@@ -156,7 +156,7 @@ export default function Home() {
                         onChange={(e) => setWidth(e.target.value)}
                       />
                     </div>
-                    <div className="md:ml-1">
+                    <div className="lg:ml-1">
                       <p>縦(px)</p>
                       <input
                         type="number"

--- a/src/pages/myList/index.jsx
+++ b/src/pages/myList/index.jsx
@@ -53,7 +53,7 @@ export default function MyListAll() {
             </div>
           </>
         )}
-        <div className="grid grid-cols-1 lg:px-8 md:px-1 md:grid-cols-3">
+        <div className="grid grid-cols-1 lg:px-8 lg:px-1 lg:grid-cols-3">
           {allMylistAnimeData.length == allMylist.length &&
             allMylistAnimeData.map((data, index) => (
               <>


### PR DESCRIPTION
# Issue番号
fixed #71 

# このPRがしたいこと
下記のようなトップページの各設定項目がスマホで操作可能なようにしたい
- ヘッダー部分の見切れとロゴの位置、フォームの幅を修正
- フォームが入力できるか
- オプションの項目で枠を選択するトグルが操作可能となっているか
- 縦横幅の値を入力可能か
- クリップボードが操作可能か

# 再現方法
Chrome DevToolsでトップページ(https://d-anime-mylist-frontend-git-fix71toppageresponsive-aruminium.vercel.app/) にアクセスし、スマホあるいはresponsiveモードで縦横幅を上記の項目を視認する

# レビュアーに確認してほしいこと

# 相談事項
iPad(横幅1158～786)は表示が崩れます（操作自体は可能）

<img src="https://user-images.githubusercontent.com/60646787/163523355-1e14a12c-3b24-4ebe-97f5-7f0cceb43d1d.png" width="50%">
<img src="https://user-images.githubusercontent.com/60646787/163522908-51e7d6dd-c796-4276-8434-cb2c9f0e7df5.png" width="50%">
<img src="https://user-images.githubusercontent.com/60646787/163522744-5be4205d-1da5-40d9-a4e3-05374bb6befa.png" width="50%">
