### PR TITLE
APIを作成

### DIFF
--- a/src/pages/api/my-list.js
+++ b/src/pages/api/my-list.js
@@ -1,0 +1,57 @@
+export default async function handler(req, res) {
+  const { method } = req;
+  console.log(method);
+
+  if (method == "GET") {
+    const {
+      query: { id },
+    } = req;
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASS_URL}/my-list?id=${id}`
+    );
+    const mylist = await response.json();
+    res.status(200).json(mylist);
+  } else if (method == "POST") {
+    const { url } = req.body;
+    console.log(url);
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASS_URL}/my-list`,
+      {
+        method: "POST", // *GET, POST, PUT, DELETE, etc.
+        mode: "cors", // no-cors, *cors, same-origin
+        cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+        credentials: "same-origin", // include, *same-origin, omit
+        headers: {
+          "Content-Type": "application/json",
+          // 'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        redirect: "follow", // manual, *follow, error
+        referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+        body: JSON.stringify({ url: url }), // 本文のデータ型は "Content-Type" ヘッダーと一致させる必要があります
+      }
+    );
+    const mylist = await response.json();
+    res.status(response.status).json(mylist);
+  } else {
+    const { url } = req.body;
+    console.log(url);
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_BASS_URL}/my-list`,
+      {
+        method: "PUT", // *GET, POST, PUT, DELETE, etc.
+        mode: "cors", // no-cors, *cors, same-origin
+        cache: "no-cache", // *default, no-cache, reload, force-cache, only-if-cached
+        credentials: "same-origin", // include, *same-origin, omit
+        headers: {
+          "Content-Type": "application/json",
+          // 'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        redirect: "follow", // manual, *follow, error
+        referrerPolicy: "no-referrer", // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+        body: JSON.stringify({ url: url }), // 本文のデータ型は "Content-Type" ヘッダーと一致させる必要があります
+      }
+    );
+    const mylist = await response.json();
+    res.status(response.status).json(mylist);
+  }
+}

--- a/src/pages/api/my-list/all.js
+++ b/src/pages/api/my-list/all.js
@@ -1,0 +1,7 @@
+export default async function handler(req, res) {
+  const response = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASS_URL}/my-list/all`
+  );
+  const mylist = await response.json();
+  res.status(200).json(mylist);
+}

--- a/src/pages/myList/[id].jsx
+++ b/src/pages/myList/[id].jsx
@@ -24,15 +24,16 @@ export default function MylistId() {
         try {
           const res = await axios.get(`/my-list?id=${id}`);
           console.log(res.data);
+          if (res.data.detail == "unknown mylist. you must register.") {
+            router.push("/404");
+            return;
+          }
           console.log(res.data.mylist);
           setMylistList(res.data.mylist);
           setAnimeInfo(res.data.mylist[0]);
           setIsLoading(false);
         } catch (err) {
-          switch (err.response?.status) {
-            case 402:
-              router.push("/404");
-          }
+          console.log(err);
         }
       }
     })();


### PR DESCRIPTION
# Issue番号

# このPRがしたいこと
EC2がSSL化されていなかった時にAPIのエンドポイントが叩けない問題を解決

# 再現方法
.env.localをrootディレクトリに配置する。以下のように記載する。
```
NEXT_PUBLIC_BASS_URL=http://localhost:3000/api
NEXT_PUBLIC_API_BASS_URL=http://localhost:80
```
*NEXT_PUBLIC_API_BASS_URL* Next.js APIが叩くエンドポイント(Docker, EC2)
*NEXT_PUBLIC_BASS_URL* Next.js フロントエンドが叩くエンドポイント(Next.js API)

# レビュアーに確認してほしいこと
1. ローカルで動作すること
2. (`NEXT_PUBLIC_API_BASS_URL=http://api.~` のように書き替えてEC2に向けてGET,POST,PUTを叩いて動作するか)
👆試してもらえると嬉しいです。

# 相談事項